### PR TITLE
[WO-406] do not use atob for decoding base64 strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "0.10"
   - "0.11"
 before_install:
+  - npm install -g npm
   - npm install -g grunt-cli
 notifications:
   email:

--- a/src/utf7.js
+++ b/src/utf7.js
@@ -62,19 +62,69 @@
         return encoded.replace(/=+$/, '');
     }
 
-    function decode(str) {
-        var octets = '',
-            r = [];
+    /**
+     * Safe base64 decoding. Does not throw on unexpected input.
+     *
+     * Implementation from the MDN docs:
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Base64_encoding_and_decoding
+     * (MDN code samples are MIT licensed)
+     *
+     * @param {String} base64Str Base64 encoded string
+     * @returns {Uint8Array} Decoded binary blob
+     */
+    function base64toTypedArray(base64Str) {
+        var bitsSoFar = 0;
+        var validBits = 0;
+        var iOut = 0;
+        var arr = new Uint8Array(Math.ceil(base64Str.length * 3 / 4));
+        var c;
+        var bits;
 
-        if (typeof window !== 'undefined' && atob) {
-            octets = atob(str);
-        } else {
-            octets = (new Buffer(str || "", "base64")).toString("binary");
+        for (var i = 0, len = base64Str.length; i < len; i++) {
+            c = base64Str.charCodeAt(i);
+            if (c >= 0x41 && c <= 0x5a) { // [A-Z]
+                bits = c - 0x41;
+            } else if (c >= 0x61 && c <= 0x7a) { // [a-z]
+                bits = c - 0x61 + 0x1a;
+            } else if (c >= 0x30 && c <= 0x39) { // [0-9]
+                bits = c - 0x30 + 0x34;
+            } else if (c === 0x2b) { // +
+                bits = 0x3e;
+            } else if (c === 0x2f) { // /
+                bits = 0x3f;
+            } else if (c === 0x3d) { // =
+                validBits = 0;
+                continue;
+            } else {
+                // ignore all other characters!
+                continue;
+            }
+            bitsSoFar = (bitsSoFar << 6) | bits;
+            validBits += 6;
+            if (validBits >= 8) {
+                validBits -= 8;
+                arr[iOut++] = bitsSoFar >> validBits;
+                if (validBits === 2) {
+                    bitsSoFar &= 0x03;
+                } else if (validBits === 4) {
+                    bitsSoFar &= 0x0f;
+                }
+            }
         }
+
+        if (iOut < arr.length) {
+            return arr.subarray(0, iOut);
+        }
+        return arr;
+    }
+
+    function decode(str) {
+        var octets = base64toTypedArray(str),
+            r = [];
 
         for (var i = 0, len = octets.length; i < len;) {
             // Calculate charcode from two adjacent bytes.
-            r.push(String.fromCharCode(octets.charCodeAt(i++) << 8 | octets.charCodeAt(i++)));
+            r.push(String.fromCharCode(octets[i++] << 8 | octets[i++]));
         }
         return r.join('');
     }


### PR DESCRIPTION
Also unifies base64 decoding in Node and in the browser (no `Buffer('base64').toString('binary')` anymore)
